### PR TITLE
fix: critical connection timeout bug

### DIFF
--- a/library.json
+++ b/library.json
@@ -35,7 +35,7 @@
       "platforms": ["espressif8266", "raspberrypi"]
     }
   ],
-  "version": "1.0.4",
+  "version": "1.0.5",
   "frameworks": "arduino",
   "platforms": ["espressif32", "raspberrypi"]
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=NetWizard
-version=1.0.4
+version=1.0.5
 author=Ayush Sharma
 category=Communication
 maintainer=Ayush Sharma <asrocks5@gmail.com>

--- a/src/NetWizard.cpp
+++ b/src/NetWizard.cpp
@@ -337,7 +337,7 @@ void NetWizard::loop() {
           // _nw.portal.exit.flag = true;
           _nw.portal.state = NetWizardPortalState::SUCCESS;
         } else {
-          if ((unsigned long)(millis() - _nw.portal.connect_millis) > NETWIZARD_EXIT_TIMEOUT) {
+          if ((unsigned long)(millis() - _nw.portal.connect_millis) > NETWIZARD_CONNECT_TIMEOUT) {
             NETWIZARD_DEBUG_MSG("Error: connection to temporary credentials timeout!\n");
             _nw.portal.sta.ssid = "";
             _nw.portal.sta.password = "";


### PR DESCRIPTION
A critical bug that affected connecting to new WiFi networks. Connection timeout was incorrectly set to 5 seconds, this lead to device unable to connect to WiFi if connection more than 5 seconds ( usually yes most of the time ).