### PR TITLE
Update NetWizard.cpp

### DIFF
--- a/src/NetWizard.cpp
+++ b/src/NetWizard.cpp
@@ -262,6 +262,7 @@ void NetWizard::loop() {
   if (_dns != nullptr) {
     // Check if DNS server is running
     if (!_dns_running) {
+      delay(100);  // Add a small delay here before checking ESP32 condition
       #if defined(ESP32)
         if (WiFi.AP.hasIP()) {
           _dns->start(53, "*", WiFi.AP.localIP());


### PR DESCRIPTION
Added delay before ESP32 DNS initialization to prevent crashes

Added a 100ms delay before checking WiFi AP IP status in the NetWizard loop function.  This delay prevents crashes that were occurring when selecting WiFi access points by  ensuring the WiFi system has adequate time to initialize before starting the DNS server.

Changes:
- Added 100ms delay before ESP32 condition check in NetWizard::loop()
- Helps prevent race condition between WiFi AP initialization and DNS server setup